### PR TITLE
Prepare for Heroku deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/fergcb/placeholder/issues"
   },
   "homepage": "https://github.com/fergcb/placeholder#readme",
+  "engines": {
+    "node": "14.x"
+  },
   "dependencies": {
     "canvas": "^2.6.1",
     "cors": "^2.8.5",

--- a/src/index.js
+++ b/src/index.js
@@ -131,5 +131,5 @@ app.get(/^(?:\/(\d+(?:x\d+)?))?(?:\/((?:[^/\\]+)))?(?:\/((?:[0-9A-Z]{3}){1,2}))?
 
 
 // Start the web server
-const port = 80
+const port = process.env.PORT || 80
 app.listen(port, () => console.log(`Listening on ${port}`))


### PR DESCRIPTION
**Changes:**
    - Add node version to `package.json`
    - Use the `PORT` environment variable provided by Heroku, or default to 80